### PR TITLE
Usunięto ograniczenie teryt_parse dla trybu DEBUG

### DIFF
--- a/teryt/management/commands/teryt_parse.py
+++ b/teryt/management/commands/teryt_parse.py
@@ -25,10 +25,6 @@ class Command(BaseCommand):
 
     @transaction.commit_manually
     def handle(self, *args, **options):
-        if settings.DEBUG:
-            raise CommandError('Django DEBUG is enabled. '
-                               'Please disable it to run this command')
-
         force_ins = not options['update']
 
         fn_dict = {


### PR DESCRIPTION
Proponuje usunąć ograniczenie, że komendę teryt_parse nie można wykonywać w trybie DEBUG. Niczemu to nie służy.