### PR TITLE
Added default manager to CommonInfo

### DIFF
--- a/teryt/models.py
+++ b/teryt/models.py
@@ -10,7 +10,7 @@ def xstr(s):
 class CommonInfo(models.Model):
     stan_na = models.DateField()
     aktywny = models.BooleanField(default=False)
-
+    objects = models.Manager()
     class Meta:
         abstract = True
 


### PR DESCRIPTION
If you declared own model manager then model get losts "objects" attribute ( see http://stackoverflow.com/questions/4455330/why-does-declaring-a-manager-to-a-django-model-void-objects ). "objects" attribute are required to teryt_parse command.