### PR TITLE
Fix for django 1.8+ (parsing args) and files in utf8

### DIFF
--- a/teryt/management/commands/teryt_auto_update.py
+++ b/teryt/management/commands/teryt_auto_update.py
@@ -17,7 +17,6 @@ from teryt.utils_zip import (
 class Command(BaseCommand):
     help = 'Import TERYT data from ZIP files prepared by GUS,\
             auto download, unpack and update with them.'
-    option_list = BaseCommand.option_list
 
     def handle(self, *args, **options):
         # download zip files from GUS site

--- a/teryt/management/commands/teryt_parse.py
+++ b/teryt/management/commands/teryt_parse.py
@@ -7,7 +7,6 @@ Option --update must be used if files have records
 already existing in database
 """
 
-from optparse import make_option
 import zipfile
 
 from django.core.management.base import BaseCommand, CommandError
@@ -18,21 +17,25 @@ from teryt.utils_zip import update_database
 class Command(BaseCommand):
     args = '[xml/zip file list]'
     help = 'Import TERYT data from XML/ZIP files prepared by GUS'
-    option_list = BaseCommand.option_list + (
-        make_option('--update',
-                    action='store_true',
-                    dest='update',
-                    default=False,
-                    help='Update exisitng data'),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('file', nargs='+', type=str)
+        parser.add_argument(
+            '--update',
+            action='store_true',
+            dest='update',
+            default=False,
+            help='Update exisitng data'
+        )
 
     def handle(self, *args, **options):
+        files = options['file']
         force_ins = not options['update']
 
-        if not args:
+        if not files:
             raise CommandError('At least 1 file name required')
 
-        for data_file in args:
+        for data_file in files:
             self.stdout.write('Working on {}'.format(data_file))
             if zipfile.is_zipfile(data_file):
                 zfile = zipfile.ZipFile(data_file)
@@ -40,7 +43,7 @@ class Command(BaseCommand):
                 with zfile.open(fname) as xml_file:
                     update_database(xml_file, fname, force_ins)
             else:
-                with open(data_file) as xml_file:
+                with open(data_file, encoding="utf8") as xml_file:
                     update_database(xml_file, data_file, force_ins)
             self.stdout.write('File {} uploaded'.format(data_file))
 

--- a/teryt/management/commands/teryt_parse.py
+++ b/teryt/management/commands/teryt_parse.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
                 with zfile.open(fname) as xml_file:
                     update_database(xml_file, fname, force_ins)
             else:
-                with open(data_file, encoding="utf8") as xml_file:
+                with open(data_file) as xml_file:
                     update_database(xml_file, data_file, force_ins)
             self.stdout.write('File {} uploaded'.format(data_file))
 

--- a/teryt/utils_zip.py
+++ b/teryt/utils_zip.py
@@ -66,6 +66,8 @@ def update_database(xml_stream, fname, force_flag):
                                   else x['SYM'])
 
             for vals in row_list:
+                if len(vals) == 0:
+                    continue
                 instance = teryt_class()
                 instance.set_val(vals)
                 instance.aktywny = True


### PR DESCRIPTION
Please verify, I tested this code with django 1.10.
Note: teryt can work also with djnago 2+ but it needs "cosmetic" changes in models/migrations like adding on_delete, etc.